### PR TITLE
Save formatted map to string #4. Also, apply `cargo fmt`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //! ```no_test
 //! cargo add knossos
 //! ```
-//! 
+//!
 //! Or add the following line to your `Cargo.toml`:
 //! ```no_test
 //! [dependencies]

--- a/src/maze/formatters/game_map.rs
+++ b/src/maze/formatters/game_map.rs
@@ -21,12 +21,12 @@ impl ExtraState for WithStartGoal {}
 
 /// A GameMap formatter for a generated maze
 ///
-/// This formatter is designed for generating game maps suitable for pseudo-3D games utilizing the ray-casting
-/// algorithm for map modeling and rendering.
+/// This formatter is designed for generating game maps suitable for pseudo-3D games utilizing the
+/// ray-casting algorithm for map modeling and rendering.
 ///
-/// By default, it generates a self-contained map without predefined start and exit points. However, it also offers
-/// the option to randomly place the start and goal points along the map borders, ensuring a viable path between the
-/// two points.
+/// By default, it generates a self-contained map without predefined start and exit points. However,
+/// it also offers the option to randomly place the start and goal points along the map borders,
+/// ensuring a viable path between the two points.
 ///
 /// # Examples:
 ///
@@ -82,7 +82,8 @@ impl GameMap<NoStartGoal> {
         }
     }
 
-    /// Returns a new instance of a [GameMap] formatter of a new type with an option to randonly spawn the start and goal characters on the borders of a map
+    /// Returns a new instance of a [GameMap] formatter of a new type with an option to randonly
+    /// spawn the start and goal characters on the borders of a map
     pub fn with_start_goal(self) -> GameMap<WithStartGoal> {
         GameMap {
             state: self.state,
@@ -112,7 +113,8 @@ impl GameMap<NoStartGoal> {
     }
 }
 
-/// An implementation of a formatter with the predefined start and goal points randomly placed along the map borders
+/// An implementation of a formatter with the predefined start and goal points randomly placed along
+/// the map borders
 impl GameMap<WithStartGoal> {
     /// Sets a goal charachter and returns itself
     pub fn goal(mut self, goal: char) -> Self {
@@ -145,7 +147,8 @@ impl GameMap<WithStartGoal> {
             .iter()
             .filter(|(nrow, ncol)| *ncol != scol && *nrow != srow)
             .nth(0)
-            .unwrap(); // the smallest grid with a single cell formatted into a map has 3 available positions for a goal
+            .unwrap(); // the smallest grid with a single cell formatted into a map has 3 available positions for a
+                       // goal
 
         let start_idx = srow * rows + scol;
         let goal_idx = grow * rows + gcol;
@@ -427,17 +430,19 @@ mod tests {
     #[test]
     fn possible_start_and_goal_positions() {
         let formatter = GameMap::new().with_start_goal();
+        #[cfg_attr(rustfmt, rustfmt_skip)]
         let map = vec![
-            '#', '#', '#', '#', '#', '#', '#', '#', '#', 
-            '#', '.', '.', '.', '#', '.', '.', '.', '#', 
+            '#', '#', '#', '#', '#', '#', '#', '#', '#',
+            '#', '.', '.', '.', '#', '.', '.', '.', '#',
             '#', '#', '#', '.', '#', '.', '#', '.', '#',
-            '#', '.', '.', '.', '#', '.', '#', '.', '#', 
-            '#', '.', '#', '#', '#', '.', '#', '.', '#', 
-            '#', '.', '.', '.', '.', '.', '#', '.', '#', 
-            '#', '#', '#', '#', '#', '#', '#', '.', '#', 
-            '#', '.', '.', '.', '.', '.', '.', '.', '#', 
+            '#', '.', '.', '.', '#', '.', '#', '.', '#',
+            '#', '.', '#', '#', '#', '.', '#', '.', '#',
+            '#', '.', '.', '.', '.', '.', '#', '.', '#',
+            '#', '#', '#', '#', '#', '#', '#', '.', '#',
+            '#', '.', '.', '.', '.', '.', '.', '.', '#',
             '#', '#', '#', '#', '#', '#', '#', '#', '#',
         ];
+        #[cfg_attr(rustfmt, rustfmt_skip)]
         let positions = vec![
             (0, 1), (0, 2), (0, 3), (0, 5), (0, 6),
             (0, 7), (1, 0), (1, 8), (2, 8), (3, 0),

--- a/src/maze/formatters/mod.rs
+++ b/src/maze/formatters/mod.rs
@@ -29,6 +29,7 @@ pub trait Saveable {
     /// In case of success, returns the string with a success message.
     /// Otherwise, returns a [MazeSaveError] with a custom reason message.
     fn save(&self, path: &str) -> Result<String, MazeSaveError>;
+    fn format(&self) -> String;
 }
 
 /// A custom wrapper over [RgbImage] for converting a maze to an image
@@ -45,6 +46,9 @@ impl Saveable for ImageWrapper {
         }
 
         Ok(format!("Maze was successfully saved as an image: {}", path))
+    }
+    fn format(&self) -> String {
+        std::string::String::new()
     }
 }
 
@@ -75,15 +79,17 @@ impl Saveable for StringWrapper {
         };
 
         match file.write_all(self.0.as_bytes()) {
-            Err(why) => {
-                Err(MazeSaveError {
-                    reason: format!("Couldn't write to {}: {}", path.display(), why),
-                })
-            }
+            Err(why) => Err(MazeSaveError {
+                reason: format!("Couldn't write to {}: {}", path.display(), why),
+            }),
             Ok(_) => Ok(format!(
                 "Maze was successfully written to a file: {}",
                 path.display()
             )),
         }
+    }
+
+    fn format(&self) -> String {
+        self.0.clone()
     }
 }

--- a/src/maze/grid/mod.rs
+++ b/src/maze/grid/mod.rs
@@ -85,11 +85,7 @@ impl Grid {
         Ok((nx, ny))
     }
 
-    pub fn get_next_cell_coords(
-        &self,
-        coords: Coords,
-        direction: Cell,
-    ) -> TransitResult<Coords> {
+    pub fn get_next_cell_coords(&self, coords: Coords, direction: Cell) -> TransitResult<Coords> {
         self.validate_transit(coords, direction)?;
 
         let (x, y) = coords;

--- a/src/maze/maze.rs
+++ b/src/maze/maze.rs
@@ -41,6 +41,16 @@ impl OrthogonalMaze {
         let data = formatter.format(&self.grid);
         Saveable::save(&data, path)
     }
+
+    // Saves a maze into a file to a given path using a given formatter
+    pub fn format<F, T>(&self, formatter: F) -> String
+    where
+        F: Formatter<T>,
+        T: Saveable,
+    {
+        let data = formatter.format(&self.grid);
+        Saveable::format(&data)
+    }
 }
 
 impl fmt::Display for OrthogonalMaze {


### PR DESCRIPTION
Enable saving a map to a string using formatters to bypass file output.